### PR TITLE
Fix/tabulated debugging output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@
 *.exe
 *.out
 *.app
+
+# Output and data files
+*.root
+*.png

--- a/resources/TabulateNuOscillator/TabulatedNuOscillator.cc
+++ b/resources/TabulateNuOscillator/TabulatedNuOscillator.cc
@@ -1281,8 +1281,7 @@ int weightTable(const char* name, int bins,
     std::cout << "reweight "
               << energyValue << " " << zenithValue
               << " with " << iEntry << "/" << entry << " entries"
-              << ", sum " << sum
-              << ", and norm " << norm
+              << ", sum: " << sum
               << std::endl;
 #endif
 

--- a/resources/TabulateNuOscillator/dumpAtmOscProb.cc
+++ b/resources/TabulateNuOscillator/dumpAtmOscProb.cc
@@ -612,30 +612,31 @@ int main(int argc, char** argv) {
 #warning "Not testing OscProb"
 #endif
 
+#define TestCUDAProb3Fixed
 #ifdef TestCUDAProb3Fixed
 #warning "Test CUDAProb3 with Fixed Production Height"
     if (oscer == "cudaprob3") {
         std::cout << "Testing CUDAProb3 with Fixed Production Height"
                   << std::endl;
         AddTable("./Configs/GUNDAM_CUDAProb3_fixed","muon","muon",
-                 "./Configs/exampleHeightBinning.root","ProductionHeight_dummy",
+                 "./Configs/exampleZenithBinning.root","ProductionHeight_dummy",
                  enrSmt,enrRes,zenSmt,zenRes);
 #define ALL_HISTOGRAMS
 #ifdef ALL_HISTOGRAMS
         AddTable("./Configs/GUNDAM_CUDAProb3_fixed","muon","electron",
-                 "./Configs/exampleHeightBinning.root","ProductionHeight_dummy",
+                 "./Configs/exampleZenithBinning.root","ProductionHeight_dummy",
                  enrSmt,enrRes,zenSmt,zenRes);
         AddTable("./Configs/GUNDAM_CUDAProb3_fixed","muon","tau",
-                 "./Configs/exampleHeightBinning.root","ProductionHeight_dummy",
+                 "./Configs/exampleZenithBinning.root","ProductionHeight_dummy",
                  enrSmt,enrRes,zenSmt,zenRes);
         AddTable("./Configs/GUNDAM_CUDAProb3_fixed","electron","electron",
-                 "./Configs/exampleHeightBinning.root","ProductionHeight_dummy",
+                 "./Configs/exampleZenithBinning.root","ProductionHeight_dummy",
                  enrSmt,enrRes,zenSmt,zenRes);
         AddTable("./Configs/GUNDAM_CUDAProb3_fixed","electron","muon",
-                 "./Configs/exampleHeightBinning.root","ProductionHeight_dummy",
+                 "./Configs/exampleZenithBinning.root","ProductionHeight_dummy",
                  enrSmt,enrRes,zenSmt,zenRes);
         AddTable("./Configs/GUNDAM_CUDAProb3_fixed","electron","tau",
-                 "./Configs/exampleHeightBinning.root","ProductionHeight_dummy",
+                 "./Configs/exampleZenithBinning.root","ProductionHeight_dummy",
                  enrSmt,enrRes,zenSmt,zenRes);
 #endif
     }
@@ -643,7 +644,7 @@ int main(int argc, char** argv) {
 #warning "Not testing CUDAProb3"
 #endif
 
-#define TestCUDAProb3Height
+#undef TestCUDAProb3Height
 #ifdef TestCUDAProb3Height
 #warning "Test CUDAProb3 with Production Height"
     if (oscer == "cudaprob3") {

--- a/resources/TabulateNuOscillator/exampleHeightBinning.py
+++ b/resources/TabulateNuOscillator/exampleHeightBinning.py
@@ -103,16 +103,21 @@ def makeProductionHeight(hBins, hMax):
 
 def fillProductionHeight(hist):
     for eBin in range(1,hist.GetXaxis().GetNbins()+1):
+        if 0 == (eBin % 100):
+            print("Fill energy band:",eBin, "of", hist.GetXaxis().GetNbins())
         for zBin in range(1,hist.GetYaxis().GetNbins()+1):
             for hBin in range(1,hist.GetZaxis().GetNbins()+1):
                 hCenter = hist.GetZaxis().GetBinCenter(hBin)
-                hProb = (hCenter - 25.0)/15
+                hProb = (hCenter - 20.0)/10
                 hProb = math.exp(-0.5*hProb*hProb)
                 hist.SetBinContent(eBin,zBin,hBin,hProb)
 
 
 def normalizeProductionHeight(hist):
     for eBin in range(1,hist.GetXaxis().GetNbins()+1):
+        if 0 == (eBin % 100):
+            print("Normalize energy band:",eBin, "of",
+                  hist.GetXaxis().GetNbins())
         for zBin in range(1,hist.GetYaxis().GetNbins()+1):
             hNorm = 0.0
             for hBin in range(1,hist.GetZaxis().GetNbins()+1):

--- a/resources/TabulateNuOscillator/exampleZenithBinning.py
+++ b/resources/TabulateNuOscillator/exampleZenithBinning.py
@@ -99,7 +99,7 @@ def makeZenith(zBins, minCos = -1.0, maxCos = 1.0, precision=1E-7):
 parser = argparse.ArgumentParser()
 parser.add_argument("--file",help="Name of the output file",
                     default="./Configs/exampleZenithBinning.root")
-parser.add_argument("-e","--energy-bins",type=int,default=300,
+parser.add_argument("-e","--energy-bins",type=int,default=1500,
                     help="Number of energy bins")
 parser.add_argument("-m","--min-energy",type=float,default=0.1,
                     help="Minimum energy (GeV)")
@@ -109,7 +109,7 @@ parser.add_argument("--energy-step",default="inverse",
                     help="Energy step (inverse or logarithmic)")
 parser.add_argument("--energy-resolution",type=float,default=0.1,
                     help="The target limit on ratio between energy steps")
-parser.add_argument("-z","--zenith-bins",type=int,default=300,
+parser.add_argument("-z","--zenith-bins",type=int,default=700,
                     help="Number of bins in zenith angle")
 parser.add_argument("--zenith-step",type=float,default=0.05,
                     help="Maximum step in cosine of the zenith angle")
@@ -126,7 +126,7 @@ zenith = makeZenith(zBins = args.zenith_bins)
 
 output = ROOT.TFile(args.file,"recreate")
 
-hist = ROOT.TH2D("zenithBinning","Zenith versus Energy bins",
+hist = ROOT.TH2D("ProductionHeight_dummy","Zenith versus Energy bins",
                  len(energies)-1,numpy.array(energies),
                  len(zenith)-1,numpy.array(zenith))
 


### PR DESCRIPTION
Clean up the debugging code a bit.  This fixes output problems in conditional debugging code, and makes sure
the cudaprob3 fixed height and distributed height tests both do something. 