### PR TITLE
Feature/no interpolation

### DIFF
--- a/resources/TabulateNuOscillator/TabulatedNuOscillator.cc
+++ b/resources/TabulateNuOscillator/TabulatedNuOscillator.cc
@@ -945,6 +945,10 @@ int weightTable(const char* name, int bins,
                     double diff = energyBinDelta(globals.oscEnergies[highE],
                                                  globals.oscEnergies[lowE]);
                     lowerBinEnergy = 1.0 - delta/diff;
+                    if (sigmaE < 0.0) {
+                        if (lowerBinEnergy < 0.5) lowerBinEnergy = 0.0;
+                        else lowerBinEnergy = 1.0;
+                    }
                 }
                 else lowerBinEnergy = 1.0;
             }
@@ -965,6 +969,10 @@ int weightTable(const char* name, int bins,
                     double diff = energyBinDelta(globals.oscEnergies[highE],
                                                  globals.oscEnergies[lowE]);
                     upperBinEnergy = 1.0 - delta/diff;
+                    if (sigmaE < 0.0) {
+                        if (upperBinEnergy <= 0.5) upperBinEnergy = 0.0;
+                        else upperBinEnergy = 1.0;
+                    }
                 }
                 else upperBinEnergy = 1.0;
             }
@@ -1024,6 +1032,10 @@ int weightTable(const char* name, int bins,
                         double diff = zenithBinDelta(globals.oscZenith[highZ],
                                                      globals.oscZenith[lowZ]);
                         lowerBinZenith = 1.0 - delta/diff;
+                        if (sigmaZ < 0.0) {
+                            if (lowerBinZenith < 0.5) lowerBinZenith = 0.0;
+                            else lowerBinZenith = 1.0;
+                        }
                     }
                     else lowerBinZenith = 1.0;
                 }
@@ -1044,6 +1056,10 @@ int weightTable(const char* name, int bins,
                         double diff = zenithBinDelta(globals.oscZenith[highZ],
                                                      globals.oscZenith[lowZ]);
                         upperBinZenith = 1.0 - delta/diff;
+                        if (sigmaZ < 0.0) {
+                            if (upperBinZenith <= 0.5) upperBinZenith = 0.0;
+                            else upperBinZenith = 1.0;
+                        }
                     }
                     else upperBinZenith = 1.0;
                 }

--- a/resources/TabulateNuOscillator/exampleZenithBinning.py
+++ b/resources/TabulateNuOscillator/exampleZenithBinning.py
@@ -22,7 +22,9 @@ def makeInverseEnergy(eBins,eMin,eMax,eRes):
     # expected to have about 20 energy bins roughly uniform in log(E), and
     # there should be at least three or four energy steps calculated per bin.
     # This leads to 80 energy grid points.
-    minFraction = math.exp(-(math.log(eMax)-math.log(eMin))/80)
+    minBins = 80
+    if (minBins > eBins/2): minBins = eBins/2
+    minFraction = math.exp(-(math.log(eMax)-math.log(eMin))/minBins)
     # When the total number of energy samples is small, the fraction must
     # be bigger.  The fraction is picked to need slightly fewer limited steps
     # than energy grid points.
@@ -75,7 +77,9 @@ def makeZenith(zBins, minCos = -1.0, maxCos = 1.0, precision=1E-7):
     maxPath = roughPathLength(minCos)
     step = (maxPath-minPath)/zBins
     print("Path length step target",step)
-    maxCosStep = (maxCos - minCos) / 80
+    minBins = 80
+    if (minBins > zBins/2): minBins = zBins/2
+    maxCosStep = (maxCos - minCos) / minBins
     lastPath = minPath
     lastCos = maxCos
     zenith = []


### PR DESCRIPTION
Extend the meaning of the energy and angular resolution values so that negative values mean no interpolation.  The current meanings are

`ENERGY_RESOLUTION` greater than zero means apply a smoothing for that relative resolution.  Reasonable values are between 0.0 and 0.1

`ENERGY_RESOLUTION` equal to zero means use linear interpolation

`ENERGY_RESOLUTION` less than zero means don't interpolate, and use the closes grid point.

The `ZENITH_RESOLUTION` definitions are analogous. 