### PR TITLE
Remove debugging output that should not be release.

### DIFF
--- a/resources/TabulateNuOscillator/TabulatedNuOscillator.cc
+++ b/resources/TabulateNuOscillator/TabulatedNuOscillator.cc
@@ -1389,7 +1389,6 @@ int updateTable(const char* name,
     TabulatedNuOscillator::NuOscillatorConfig& config
         = TabulatedNuOscillator::configLookup[configName];
 
-#define DEBUG_UPDATE_TABLE
 #ifdef DEBUG_UPDATE_TABLE
     LIB_COUT << "Fill table " << name
              << " @ " << (void*) table


### PR DESCRIPTION
Closes #35 

The debugging statement that causes the output problem is removed.